### PR TITLE
Adding to local refactoring

### DIFF
--- a/src/agent/onefuzz-task/src/local/libfuzzer_basic.yml
+++ b/src/agent/onefuzz-task/src/local/libfuzzer_basic.yml
@@ -32,3 +32,15 @@ tasks:
     check_retry_count: ""
     minimized_stack_depth: ""
     check_queue: ""
+
+  - type: "Coverage"
+    target_exe: *target_exe
+    target_env: *target_env
+    target_options: ""
+    target_timeout: ""
+    input_queue: *coverage
+    readonly_inputs: []
+    coverage: *coverage
+    module_allowlist: ""
+    source_allowlist: ""
+      

--- a/src/agent/onefuzz-task/src/local/libfuzzer_basic.yml
+++ b/src/agent/onefuzz-task/src/local/libfuzzer_basic.yml
@@ -4,25 +4,25 @@
 # target_exe: &target_exe "dsfdsfd"
 # # setup_dir: &"adsda"
 # # extra_dir: &"asd"
-target_env: []
-target_options: []
+
+target_args: &target_args
+  target_env: {}
+  target_exe: ""
+  target_options: []
+  target_timeout: 1
+
 tasks:
   - type: LibFuzzer
+    <<: *target_args
     inputs:  ""
     readonly_inputs: []
     crashes: &test "c:\\temp"
-    target_exe: *target_exe
-    target_env: *target_env
-    target_options: ""
     ensemble_sync_delay: ""
     check_fuzzer_help: ""
 
 
   - type: "Report"
-    target_exe: *target_exe
-    target_env: *target_env
-    target_options: ""
-    target_timeout: ""
+    <<: *target_args
     input_queue: *crash
     crashes: *crash
     reports: ""
@@ -34,10 +34,7 @@ tasks:
     check_queue: ""
 
   - type: "Coverage"
-    target_exe: *target_exe
-    target_env: *target_env
-    target_options: ""
-    target_timeout: ""
+    <<: *target_args
     input_queue: *coverage
     readonly_inputs: []
     coverage: *coverage

--- a/src/agent/onefuzz-task/src/local/libfuzzer_basic.yml
+++ b/src/agent/onefuzz-task/src/local/libfuzzer_basic.yml
@@ -1,43 +1,44 @@
-
 # yaml-language-server: $schema=schema.json
 
-# target_exe: &target_exe "dsfdsfd"
-# # setup_dir: &"adsda"
-# # extra_dir: &"asd"
+# What I had to do to get this working:
+# 1. Update target_exe to point to the target exe
+# 2. From the directory in which I'm running onefuzz-task, create the following folders/files
+#     * ./etc/machine_name -> Where I wrote the value `local_machine`  \
+#     * ./etc/scaleset_name -> Where I wrote the value `local`         / ----- These 2 allow us to omit setting ONEFUZZ_ROOT env var
+#     * ./inputs/
+#     * ./crashes/
+#     Ideally (in my opinion), this folder/file setup should be automated but remain configurable if desired
+# 3. Install llvm and export LLVM_SYMBOLIZER_PATH like we do in setup.sh
 
 target_args: &target_args
   target_env: {}
-  target_exe: ""
+  target_exe: "/workspaces/onefuzz/onefuzz-samples/examples/simple-libfuzzer/fuzz.exe"
   target_options: []
-  target_timeout: 1
 
 tasks:
   - type: LibFuzzer
     <<: *target_args
-    inputs:  ""
+    inputs: "./inputs"
+    crashes: "./crashes"
     readonly_inputs: []
-    crashes: &test "c:\\temp"
-    ensemble_sync_delay: ""
-    check_fuzzer_help: ""
+    check_fuzzer_help: true
 
+  # - type: "Report"
+  #   <<: *target_args
+  #   input_queue: *crash
+  #   crashes: *crash
+  #   reports: ""
+  #   unique_reports: ""
+  #   no_repro: ""
+  #   check_fuzzer_help: ""
+  #   check_retry_count: ""
+  #   minimized_stack_depth: ""
+  #   check_queue: ""
 
-  - type: "Report"
-    <<: *target_args
-    input_queue: *crash
-    crashes: *crash
-    reports: ""
-    unique_reports: ""
-    no_repro: ""
-    check_fuzzer_help: ""
-    check_retry_count: ""
-    minimized_stack_depth: ""
-    check_queue: ""
-
-  - type: "Coverage"
-    <<: *target_args
-    input_queue: *coverage
-    readonly_inputs: []
-    coverage: *coverage
-    module_allowlist: ""
-    source_allowlist: ""
-      
+  # - type: "Coverage"
+  #   <<: *target_args
+  #   input_queue:
+  #     path: "./coverage"
+  #   readonly_inputs: []
+  #   module_allowlist: ""
+  #   source_allowlist: ""

--- a/src/agent/onefuzz-task/src/local/libfuzzer_basic.yml
+++ b/src/agent/onefuzz-task/src/local/libfuzzer_basic.yml
@@ -7,6 +7,7 @@
 #     * ./etc/scaleset_name -> Where I wrote the value `local`         / ----- These 2 allow us to omit setting ONEFUZZ_ROOT env var
 #     * ./inputs/
 #     * ./crashes/
+#     * ./coverage/
 #     Ideally (in my opinion), this folder/file setup should be automated but remain configurable if desired
 # 3. Install llvm and export LLVM_SYMBOLIZER_PATH like we do in setup.sh
 
@@ -35,10 +36,10 @@ tasks:
   #   minimized_stack_depth: ""
   #   check_queue: ""
 
-  # - type: "Coverage"
-  #   <<: *target_args
-  #   input_queue:
-  #     path: "./coverage"
-  #   readonly_inputs: []
-  #   module_allowlist: ""
-  #   source_allowlist: ""
+  - type: "Coverage"
+    <<: *target_args
+    target_options:
+      - "{input}"
+    input_queue: "./inputs"
+    readonly_inputs: []
+    coverage: "./coverage"

--- a/src/agent/onefuzz-task/src/local/schema.json
+++ b/src/agent/onefuzz-task/src/local/schema.json
@@ -1,11 +1,10 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "TaskGroup",
-  "description": "A group of task to run",
+  "description": "A group of tasks to run",
   "type": "object",
   "required": [
-    "target_env",
-    "target_options",
+    "target_args",
     "tasks"
   ],
   "properties": {
@@ -72,9 +71,33 @@
       "items": {
         "$ref": "#/definitions/TaskConfig"
       }
+    },
+    "target_args": {
+      "$ref": "#/definitions/TargetArgs"
     }
   },
   "definitions": {
+    "TargetArgs": {
+      "description": "Required for running a target",
+      "type": "object",
+      "properties": {
+        "target_env": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "target_exe": {
+          "type": "string"
+        },
+        "target_options": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "FolderWatch": {
       "type": "object",
       "required": [

--- a/src/agent/onefuzz-task/src/local/schema.json
+++ b/src/agent/onefuzz-task/src/local/schema.json
@@ -106,16 +106,7 @@
       }
     },
     "FolderWatch": {
-      "type": "object",
-      "required": [
-        "path"
-      ],
-      "properties": {
-        "path": {
-          "description": "The path to watch",
-          "type": "string"
-        }
-      }
+      "type": "string"
     },
     "TaskConfig": {
       "oneOf": [
@@ -286,8 +277,7 @@
           ],
           "properties": {
             "coverage": {
-              "type": "string",
-              "default": "./onefuzz_coverage.json"
+              "type": "string"
             },
             "input_queue": {
               "anyOf": [

--- a/src/agent/onefuzz-task/src/local/schema.json
+++ b/src/agent/onefuzz-task/src/local/schema.json
@@ -73,7 +73,14 @@
       }
     },
     "target_args": {
-      "$ref": "#/definitions/TargetArgs"
+      "anyOf": [
+        {
+          "$ref": "#/definitions/TargetArgs"
+        },
+        {
+          "type": "null"
+        }
+      ]
     }
   },
   "definitions": {
@@ -271,7 +278,6 @@
         {
           "type": "object",
           "required": [
-            "coverage",
             "readonly_inputs",
             "target_env",
             "target_exe",
@@ -280,7 +286,8 @@
           ],
           "properties": {
             "coverage": {
-              "type": "string"
+              "type": "string",
+              "default": "./onefuzz_coverage.json"
             },
             "input_queue": {
               "anyOf": [

--- a/src/agent/onefuzz-task/src/local/template.rs
+++ b/src/agent/onefuzz-task/src/local/template.rs
@@ -27,7 +27,7 @@ use crate::tasks::{
 use super::common::{DirectoryMonitorQueue, SyncCountDirMonitor, UiEvent};
 use anyhow::Result;
 
-use futures::future::OptionFuture;
+use futures::{future::OptionFuture, task};
 
 use schemars::{schema_for, JsonSchema};
 
@@ -43,10 +43,6 @@ pub struct TaskGroup {
 #[derive(Debug, Deserialize, Serialize, Clone, JsonSchema)]
 
 struct CommonProperties {
-    pub job_id: Option<Uuid>,
-    pub target_exe: Option<PathBuf>,
-    pub target_options: Vec<String>,
-    pub target_env: Vec<(String, String)>,
     pub setup_dir: Option<PathBuf>,
     pub extra_setup_dir: Option<PathBuf>,
     pub extra_dir: Option<PathBuf>,
@@ -369,9 +365,10 @@ pub async fn launch(
     value.apply_merge()?;
 
     let task_group: TaskGroup = serde_yaml::from_value(value)?;
+
     let common = CommonConfig {
         task_id: Uuid::nil(),
-        job_id: task_group.common.job_id.unwrap_or(Uuid::new_v4()),
+        job_id: Uuid::new_v4(),
         instance_id: Uuid::new_v4(),
         heartbeat_queue: None,
         instance_telemetry_key: None,

--- a/src/agent/onefuzz-task/src/local/template.rs
+++ b/src/agent/onefuzz-task/src/local/template.rs
@@ -14,12 +14,12 @@ use tokio::{sync::Mutex, task::JoinHandle};
 
 use crate::tasks::{
     config::CommonConfig,
+    coverage::generic::{
+        
+    },
     fuzz::{
         self,
-        libfuzzer::{
-            common::default_workers,
-            generic::LibFuzzerFuzzTask,
-        },
+        libfuzzer::{common::default_workers, generic::LibFuzzerFuzzTask},
     },
     report,
 };
@@ -27,7 +27,7 @@ use crate::tasks::{
 use super::common::{DirectoryMonitorQueue, SyncCountDirMonitor, UiEvent};
 use anyhow::Result;
 
-use futures::{future::OptionFuture};
+use futures::future::OptionFuture;
 
 use schemars::{schema_for, JsonSchema};
 
@@ -63,10 +63,11 @@ struct FolderWatch {
 
 impl From<String> for FolderWatch {
     fn from(path: String) -> Self {
-        Self { path: PathBuf::from(path) }
+        Self {
+            path: PathBuf::from(path),
+        }
     }
 }
-
 
 #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema)]
 struct LibFuzzer {
@@ -187,7 +188,9 @@ impl TaskConfig {
                     .await;
             }
             TaskConfig::Analysis(_analysis) => {}
-            TaskConfig::Coverage(_) => todo!(),
+            TaskConfig::Coverage(config) => {
+                let coverage_config = coverage::generic::Config {};
+            }
             TaskConfig::Report(config) => {
                 let input_q_fut: OptionFuture<_> = config
                     .input_queue
@@ -360,15 +363,11 @@ pub async fn launch(
     Ok(())
 }
 
-
-
 mod test {
     use schemars;
     #[test]
     fn test() {
         let schema = schemars::schema_for!(super::TaskGroup);
         println!("{}", serde_json::to_string_pretty(&schema).unwrap());
-
     }
-
 }


### PR DESCRIPTION
* Added generic coverage task
* Added `target_args` to the schema so we can reuse them across tasks using anchors
* Libfuzzer task is runnable and documented what steps need to be done before (like creating files)
* Coverage task works (process inputs from ./inputs/ and outputs coverage to ./coverage/)
* To render coverage as HTML:
    * `pip install pycobertura`
    * `pycobertura show --format html --output coverage.html coverage/cobertura-coverage.xml`
    * Open `coverage.html` in your browser OR in VSCode use the [Live Server extension](https://marketplace.visualstudio.com/items?itemName=ritwickdey.LiveServer)
    * Note: I tried to get this to work natively in VSCode but it seems we need to produce lcov files instead of cobertura